### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete URL substring sanitization

### DIFF
--- a/py-pyramid-agno/airbnb_assistant/ai/agent.py
+++ b/py-pyramid-agno/airbnb_assistant/ai/agent.py
@@ -5,6 +5,7 @@ import logging
 import os
 import shutil
 from typing import Dict, Any, Optional, List, Union
+from urllib.parse import urlparse
 
 # Import Agno components with error handling
 try:
@@ -174,7 +175,8 @@ class AirbnbAssistantAgent:
         # Replace the URL placeholders back
         for placeholder, (display_text, url) in urls.items():
             # Check if this is an image URL from Airbnb
-            if 'a0.muscache.com' in url and not url.endswith(('.pdf', '.doc', '.txt')):
+            parsed_url = urlparse(url)
+            if parsed_url.hostname == 'a0.muscache.com' and not url.endswith(('.pdf', '.doc', '.txt')):
                 text = text.replace(placeholder, f"\n![{display_text}]({url})\n")
             else:
                 text = text.replace(placeholder, f"[{display_text}]({url})")


### PR DESCRIPTION
Potential fix for [https://github.com/cf-toolsuite/tanzu-genai-showcase/security/code-scanning/1](https://github.com/cf-toolsuite/tanzu-genai-showcase/security/code-scanning/1)

To fix the problem, we need to parse the URL and check its hostname instead of using a substring check. This ensures that the URL is correctly identified as belonging to the allowed domain. We can use the `urlparse` function from the `urllib.parse` module to achieve this.

- Parse the URL using `urlparse`.
- Extract the hostname from the parsed URL.
- Check if the hostname matches the allowed domain.

We will make changes to the `_format_response_as_markdown` method in the `py-pyramid-agno/airbnb_assistant/ai/agent.py` file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
